### PR TITLE
Revert renaming of param field to chainage

### DIFF
--- a/rivertopo/snapping.py
+++ b/rivertopo/snapping.py
@@ -6,7 +6,7 @@ from collections import namedtuple
 
 ogr.UseExceptions()
 
-SnapResult = namedtuple('SnapResult', ['feature', 'segment', 'chainage', 'offset'])
+SnapResult = namedtuple('SnapResult', ['feature', 'segment', 'param', 'offset'])
 
 def snap_points(points, feature_id, linestring):
     """
@@ -57,7 +57,7 @@ def snap_points(points, feature_id, linestring):
         snap_results.append(SnapResult(
             feature=feature_id,
             segment=closest_segment_index,
-            chainage=linestring_vector_projparams[closest_segment_index],
+            param=linestring_vector_projparams[closest_segment_index],
             offset=offset,
         ))
 

--- a/tests/test_snapping.py
+++ b/tests/test_snapping.py
@@ -21,14 +21,14 @@ def test_snap_points():
     ])
 
     expected_results = [
-        SnapResult(feature=42, segment=0, chainage=0.28, offset=-0.2),
-        SnapResult(feature=42, segment=1, chainage=0.25, offset=-0.5),
-        SnapResult(feature=42, segment=1, chainage=0.75, offset=0.5),
+        SnapResult(feature=42, segment=0, param=0.28, offset=-0.2),
+        SnapResult(feature=42, segment=1, param=0.25, offset=-0.5),
+        SnapResult(feature=42, segment=1, param=0.75, offset=0.5),
     ]
 
     snap_results = snap_points(points, feature_id, linestring)
 
     assert [actual.feature for actual in snap_results] == [expected.feature for expected in expected_results]
     assert [actual.segment for actual in snap_results] == [expected.segment for expected in expected_results]
-    assert np.allclose([actual.chainage for actual in snap_results], [expected.chainage for expected in expected_results])
+    assert np.allclose([actual.param for actual in snap_results], [expected.param for expected in expected_results])
     assert np.allclose([actual.offset for actual in snap_results], [expected.offset for expected in expected_results])


### PR DESCRIPTION
Revert rename since the field does not represent an arc-length parameterization.